### PR TITLE
fixes #9

### DIFF
--- a/R/RRStr.r
+++ b/R/RRStr.r
@@ -15,7 +15,7 @@
 #' @param divider internal control parameter for algorithm
 #' @return A \code{\link{rrstr}} object with the following fields:
 #'  \item{estimate}{matrix of point and interval estimates - starting value, MLE, and skewness corrected}
-#'  \item{hom}{list of homogeneity statistic, p-value, and degrees of freedom}
+#'  \item{hom}{list of homogeneity statistic, p-value, and degrees of freedom, or error message if appropriate.}
 #'  \item{estimator}{either \code{"PF"} or \code{"RR"}}
 #'  \item{y}{Y matrix of the data}
 #'  \item{compare}{groups compared}
@@ -54,21 +54,28 @@
 #' ## or as matrix
 #' RRstr(Y = table6, pf = FALSE)
 #' 
+#' tst <- data.frame(y = c(0, 2, 0, 4, 0, 3, 0, 7),
+#' n = rep(10, 8),
+#' tx = rep(c('a', 'b'), 4),
+#' clus = rep(paste('Row', 1:4, sep = ''), each = 2))
+#' 
+#' RRstr(cbind(y,n) ~ tx + cluster(clus), tst)
+#' #  Homogeneity test not possible because MLE =  1 
+#' #   
+#' #  PF 
+#' #  95% interval estimates
+#' #   
+#' #  PF    LL UL
+#' #  starting   1 0.000  1
+#' #  mle        1 0.783  1
+#' #  skew corr  1 0.827  1
 ##--------------------------------------------------------------------
 ## RRstr function
 ##--------------------------------------------------------------------
 RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha = 0.05, 
 	pf = TRUE, trace.it = FALSE, iter.max = 24, converge = 1e-6, rnd = 3, multiplier = 0.7, 
 	divider = 1.1){
-# stratified risk ratio (Gart and Nam, 1988)
-#  coded by D. Siev 1993
-#  modified by Siev 3/14/2010 to fix bug
-#  modified by Siev 5/12/2010 to stabilize algorithm
-#   5/17/2010 moved optimization into separate internal function
-#   9/24/2010 added formula-dataframe data entry
-#	11/25/2010 minor change in convergence
-
-#---------------------------------------
+  
 # define internal functions:
 #  u.p, zi.phi, zis.phi, root, rr.opt, matricize
  
@@ -78,7 +85,7 @@ RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha =
     zi.phi <- function(phi, Y, u.p, root, za){
     # for score interval in RRstr
         zi <- ui <- 0
-        for(i in 1:nrow(Y)) {
+        for (i in 1:nrow(Y)) {
             y1 <- Y[i, 1]
             n1 <- Y[i, 2]
             y2 <- Y[i, 3]
@@ -86,7 +93,7 @@ RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha =
             p2 <- root(y1, y2, n1, n2, phi)
             p1 <- p2 * phi
             u <- u.p(p1, p2, n1, n2)
-            u[u<0] <- NA
+            u[u < 0] <- NA
             zz <- ((y1 - n1 * p1)/(1 - p1))
             z <- zz * sqrt(u)
             zd <- abs(z - za)
@@ -100,7 +107,7 @@ RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha =
     zis.phi <- function(phi, Y, u.p, root, za){
     # for skewness-corrected interval in RRstr
         zi <- ui <- gi <- 0
-        for(i in 1:nrow(Y)) {
+        for (i in 1:nrow(Y)) {
             y1 <- Y[i, 1]
             n1 <- Y[i, 2]
             y2 <- Y[i, 3]
@@ -110,7 +117,7 @@ RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha =
             q1 <- 1 - p1
             q2 <- 1 - p2
             u <- u.p(p1, p2, n1, n2)
-            u[u<0] <- NA
+            u[u < 0] <- NA
             zz <- ((y1 - n1 * p1)/(1 - p1))
             z.ph <- zz * sqrt(u)
             g <- (q1 * (q1 - p1))/(n1 * p1)^2 - (q2 * (q2 - p2))/(n2 * p2)^2
@@ -128,36 +135,36 @@ RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha =
     root <- function(y1, y2, n1, n2, phi){
 		# in RRstr
         a <- phi * (n1 + n2)
-        b <-  - (phi * (y2 + n1) + y1 + n2)
+        b <-  -(phi * (y2 + n1) + y1 + n2)
         cc <- y1 + y2
         det <- sqrt(b^2 - 4 * a * cc)
-        r1 <- ( - b + det)/(2 * a)
-        r2 <- ( - b - det)/(2 * a)
+        r1 <- (-b + det)/(2 * a)
+        r2 <- (-b - det)/(2 * a)
         r1 <- round(r1, 8) ## round for comparison
         r2 <- round(r2, 8) ##
-        if(r1 < 0 || r1 > 1) r1 <- r2
-        if(r2 < 0 || r2 > 1) r2 <- r1
+        if (r1 < 0 || r1 > 1) r1 <- r2
+        if (r2 < 0 || r2 > 1) r2 <- r1
         return(c(r1, r2))
     }
 
     rr.opt <- function(z.phi, phi,za, divider, trace.it, u.p, root){
     # optimizer function for RRstr
         zz <- c(z.phi(phi[1], Y, u.p, root, za), z.phi(phi[2], Y, u.p, root, za))
-        if(abs(za - zz[1]) > abs(za - zz[2]))  phi <- rev(phi)
+        if (abs(za - zz[1]) > abs(za - zz[2]))  phi <- rev(phi)
         phi.new <- phi[1]
         phi.old <- phi[2]
         z.old <- z.phi(phi.old, Y, u.p, root, za)
-        if(trace.it) cat('\n\nR start', phi, '\n')
+        if (trace.it) cat('\n\nR start', phi, '\n')
         iter <- 0
         repeat {
             iter <- iter + 1
             z.new <- z.phi(phi.new, Y, u.p, root, za)
-            if(is.na(z.new)) f <- 1 ## adjust step
-            while(is.na(z.new)){
+            if (is.na(z.new)) f <- 1 ## adjust step
+            while (is.na(z.new)) {
                 phi.new <- phi.old + (phi.new - phi.old) / f
                 z.new <- z.phi(phi.new, Y, u.p, root, za)
                 f <- f * (1/divider) 
-                if(trace.it) cat('Step adjustment =', 1/f, '\n')
+                if (trace.it) cat('Step adjustment =', 1/f, '\n')
             }
 
             phi <- exp(log(phi.old) + log(phi.new/phi.old) * ((za - z.old)/(z.new - z.old)))
@@ -165,10 +172,10 @@ RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha =
             z.old <- z.new
             phi.new <- phi
 
-            if(trace.it)
+            if (trace.it)
                 cat("iteration", iter, "  z", z.new, "phi", phi.new, "\n")
-            if(abs(za - z.new) < converge) break
-            if(iter == iter.max){ # no convergence 
+            if (abs(za - z.new) < converge) break
+            if (iter == iter.max) { # no convergence 
                 cat('\nIteration limit reached without convergence\n')
                 break
             }
@@ -183,7 +190,7 @@ RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha =
 
 # convert to matrix
 
-    if(!is.null(formula) & !is.null(data)){
+    if (!is.null(formula) & !is.null(data)) {
         Y <- .matricize(formula = formula, data = data, compare = compare)$Y
     }
 
@@ -192,7 +199,7 @@ RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha =
 
     zv <- qnorm(c(alpha / 2, 1 - alpha / 2))
     numer <- denom <- uu <- 0
-    for(i in 1:nrow(Y)) {
+    for (i in 1:nrow(Y)) {
         y1 <- Y[i, 1]
         n1 <- Y[i, 2]
         y2 <- Y[i, 3]
@@ -212,17 +219,17 @@ RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha =
     # if all zeros or ones estimate only one end of interval
     which <- 1:2 
     score <- rep(0, 2)
-    if(numer == 0){
+    if (numer == 0) {
         int[1] <- score[1] <- 0
         int[2] <- 1
         which <- 2 
     }
-    if(denom == 0){
+    if (denom == 0) {
         int[2] <- score[2] <- 1
         int[1] <- 0
         which <- 1 
     }
-    if(trace.it) {
+    if (trace.it) {
         cat("\nstarting estimates:")
         print(int)
     }
@@ -230,19 +237,19 @@ RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha =
 #---------------------------------------
 # get MLE of R
 # and test for heterogeneity
-    if(Phi == 0 | Phi == 1){
+    if (Phi == 0 | Phi == 1) {
         Phi.ML <- Phi
         hom <- paste('MLE = ',Phi.ML,', Homogeneity test not possible', sep = '')
-    } else{
+    } else {
         za <-  0
         phi <- c(Phi, multiplier * Phi)
-        if(trace.it) cat('\nMLE')
+        if (trace.it) cat('\nMLE')
         phi.new <- rr.opt(z.phi = zi.phi, phi = phi, za = za, divider = divider,
 			trace.it = trace.it, u.p = u.p, root = root)
         Phi.ML <- phi.new
             # test for homogeneity of phi's
         test <- rep(0, nrow(Y))
-        for(i in 1:nrow(Y)){
+        for (i in 1:nrow(Y)) {
             test[i] <- zi.phi(Phi.ML, t(as.matrix(Y[i, ])), u.p, root, za)^2
 		}
         hom.test <- sum(test)
@@ -253,8 +260,8 @@ RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha =
 #---------------------------------------
 
 # Score intervals
-    for(k in which) {
-        if(trace.it) cat('\nScore',switch(k, 'lower', 'upper'))
+    for (k in which) {
+        if (trace.it) cat('\nScore',switch(k, 'lower', 'upper'))
         za <-  -zv[k]
         phi <- c(int[k], multiplier * int[k])
         phi.new <- rr.opt(z.phi = zi.phi, phi = phi, za = za, divider = divider,
@@ -264,8 +271,8 @@ RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha =
     int <- rbind(int, score)
 
 # Skewness-corrected intervals
-    for(k in which) {
-        if(trace.it) cat('\nSkewness-corrected',switch(k,'lower','upper'))
+    for (k in which) {
+        if (trace.it) cat('\nSkewness-corrected',switch(k,'lower','upper'))
         za <-  -zv[k]
         phi <- c(int[1, k], multiplier * int[1, k])
         phi.new <- rr.opt(z.phi = zis.phi, phi = phi, za = za, divider = divider,
@@ -275,8 +282,8 @@ RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha =
 
     int <- rbind(int, score)
     int <- cbind(c(Phi, rep(Phi.ML, nrow(int) - 1)), int)
-    if(trace.it) cat("\n\n")
-    if(!pf){
+    if (trace.it) cat("\n\n")
+    if (!pf) {
 		dimnames(int) <- list(c("starting", "mle", "skew corr"), c("RR", "LL", "UL"))
 	} else {
         int <- 1 - int[, c(1, 3, 2)]
@@ -284,8 +291,5 @@ RRstr <- function(formula = NULL, data = NULL, compare = c('b', 'a'), Y, alpha =
     }
     return(rrstr$new(estimate = int, hom = hom, estimator = ifelse(pf, 'PF', 'RR'), 
 		y = Y, compare = compare, rnd = rnd, alpha = alpha))
-    # out <- list(estimate = int, hom = hom, estimator = ifelse(pf, 'PF', 'RR'), Y = Y, compare = compare, rnd = rnd, alpha = alpha)
-    # class(out) <- 'rrstr'
-    # return(out)
 }
 

--- a/R/class.r
+++ b/R/class.r
@@ -1,3 +1,5 @@
+setClassUnion("listORchar", c("list", "character"))
+
 #' @title Data class pf
 # @name pf-class
 #' @description data class pf
@@ -129,7 +131,9 @@ rrsc <- setRefClass('rrsc', contains = 'pf', fields = list(estimate = 'matrix',
 #' \item[\code{rnd}]{  how many digits to round display}
 #' \item[\code{alpha}]{  complement of c.i.}
 #' \item[\code{estimator}]{  either \code{"PF"} or \code{"RR"}}
-#' \item[\code{hom}]{  list of homogeneity statistic, p-value, and degrees of freedom}
+#' \item[\code{hom}]{list of homogeneity statistic, p-value, and degrees of freedom.
+#' If \code{Phi == 0 | Phi == 1}, homogenity test is not possible and error message
+#' displays}
 #' \item[\code{y}]{  matrix of data}
 #' \item[\code{compare}]{  groups compared}
 #' }
@@ -137,5 +141,5 @@ rrsc <- setRefClass('rrsc', contains = 'pf', fields = list(estimate = 'matrix',
 #' @export
 #' @author Marie Vendettuoli \email{marie.c.vendettuoli@@aphis.usda.gov}
 rrstr <- setRefClass('rrstr', contains = 'pf', fields = list(estimate = 'matrix',
-	hom = 'list', y = 'matrix', compare = 'character'))
+  hom = 'listORchar', y = 'matrix', compare = 'character'))
 	

--- a/R/class.r
+++ b/R/class.r
@@ -132,7 +132,7 @@ rrsc <- setRefClass('rrsc', contains = 'pf', fields = list(estimate = 'matrix',
 #' \item[\code{alpha}]{  complement of c.i.}
 #' \item[\code{estimator}]{  either \code{"PF"} or \code{"RR"}}
 #' \item[\code{hom}]{list of homogeneity statistic, p-value, and degrees of freedom.
-#' If \code{Phi == 0 | Phi == 1}, homogenity test is not possible and error message
+#' If \code{Phi == 0 | Phi == 1}, homogeneity test is not possible and error message
 #' displays}
 #' \item[\code{y}]{  matrix of data}
 #' \item[\code{compare}]{  groups compared}

--- a/man/RRstr.Rd
+++ b/man/RRstr.Rd
@@ -36,7 +36,7 @@ RRstr(formula = NULL, data = NULL, compare = c("b", "a"), Y,
 \value{
 A \code{\link{rrstr}} object with the following fields:
  \item{estimate}{matrix of point and interval estimates - starting value, MLE, and skewness corrected}
- \item{hom}{list of homogeneity statistic, p-value, and degrees of freedom}
+ \item{hom}{list of homogeneity statistic, p-value, and degrees of freedom, or error message if appropriate.}
  \item{estimator}{either \code{"PF"} or \code{"RR"}}
  \item{y}{Y matrix of the data}
  \item{compare}{groups compared}
@@ -79,6 +79,21 @@ RRstr(cbind(y,n) ~ tx + cluster(clus), Table6 , pf = FALSE)
 ## or as matrix
 RRstr(Y = table6, pf = FALSE)
 
+tst <- data.frame(y = c(0, 2, 0, 4, 0, 3, 0, 7),
+n = rep(10, 8),
+tx = rep(c('a', 'b'), 4),
+clus = rep(paste('Row', 1:4, sep = ''), each = 2))
+
+RRstr(cbind(y,n) ~ tx + cluster(clus), tst)
+#  Homogeneity test not possible because MLE =  1 
+#   
+#  PF 
+#  95\% interval estimates
+#   
+#  PF    LL UL
+#  starting   1 0.000  1
+#  mle        1 0.783  1
+#  skew corr  1 0.827  1
 }
 \references{
 Gart JJ, 1985. Approximate tests and interval estimation of the common relative risk in the combination of \eqn{2 x 2} tables. \emph{Biometrika} 72:673-677.

--- a/man/rrstrclass.Rd
+++ b/man/rrstrclass.Rd
@@ -16,7 +16,9 @@ data class rrstr
 \item[\code{rnd}]{  how many digits to round display}
 \item[\code{alpha}]{  complement of c.i.}
 \item[\code{estimator}]{  either \code{"PF"} or \code{"RR"}}
-\item[\code{hom}]{  list of homogeneity statistic, p-value, and degrees of freedom}
+\item[\code{hom}]{list of homogeneity statistic, p-value, and degrees of freedom.
+If \code{Phi == 0 | Phi == 1}, homogenity test is not possible and error message
+displays}
 \item[\code{y}]{  matrix of data}
 \item[\code{compare}]{  groups compared}
 }

--- a/man/rrstrclass.Rd
+++ b/man/rrstrclass.Rd
@@ -17,7 +17,7 @@ data class rrstr
 \item[\code{alpha}]{  complement of c.i.}
 \item[\code{estimator}]{  either \code{"PF"} or \code{"RR"}}
 \item[\code{hom}]{list of homogeneity statistic, p-value, and degrees of freedom.
-If \code{Phi == 0 | Phi == 1}, homogenity test is not possible and error message
+If \code{Phi == 0 | Phi == 1}, homogeneity test is not possible and error message
 displays}
 \item[\code{y}]{  matrix of data}
 \item[\code{compare}]{  groups compared}


### PR DESCRIPTION
Example case where homogeneity test not possible:

```r
tst <- data.frame(y = c(0, 2, 0, 4, 0, 3, 0, 7),
                  n = rep(10, 8),
                  tx = rep(c('a', 'b'), 4),
                  clus = rep(paste('Row', 1:4, sep = ''), each = 2))

RRstr(cbind(y,n) ~ tx + cluster(clus), tst)
#  Homogeneity test not possible because MLE =  1 
#   
#  PF 
#  95% interval estimates
#   
#  PF    LL UL
#  starting   1 0.000  1
#  mle        1 0.783  1
#  skew corr  1 0.827  1
```